### PR TITLE
Add Site information update function using graphQL

### DIFF
--- a/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
+++ b/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
@@ -28,12 +28,12 @@ const SiteCreateModal = (): ReactElement => {
       term: 'd',
     },
     validationSchema: Yup.object({
-      site: Yup.string().required(`"Title"은 필수 입력 항목입니다.`),
+      site: Yup.string().required(`"Title" is a required field`),
       url: Yup.string()
-        .url(`올바르지 않은 "url"입니다.`)
-        .required(`"url"은 필수 입력 항목입니다.`),
-      domain: Yup.string().required(`"domain"은 필수 입력 항목입니다.`),
-      term: Yup.string().required(`"term"은 필수 입력 항목입니다.`),
+        .url(`invalid url address`)
+        .required(`"url" is a required field`),
+      domain: Yup.string().required(`"domain" is a required field`),
+      term: Yup.string().required(`"term" is a required field`),
     }),
     onSubmit: () => {},
   });
@@ -64,6 +64,30 @@ const SiteCreateModal = (): ReactElement => {
     if (loading) return;
     formik.submitForm();
     if (!formik.isValid) {
+      return;
+    }
+    const domainFromUrl = formik.values.url.match(
+      /^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i,
+    );
+    const domainFromDomain = formik.values.domain.match(
+      /^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i,
+    );
+
+    if (!domainFromUrl || domainFromUrl.length < 2) {
+      formik.setFieldError('url', 'invalid url');
+      return;
+    } else if (
+      domainFromUrl[1] !==
+      ((domainFromDomain && domainFromDomain[1]) || formik.values.domain)
+    ) {
+      formik.setFieldError(
+        'url',
+        'Domain name of this field must match the one entered for "Domain"',
+      );
+      formik.setFieldError(
+        'domain',
+        'Domain name must match the one entered for "Crawling URL"',
+      );
       return;
     }
 
@@ -161,7 +185,7 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-url"
-                >{`Url to crawl`}</label>
+                >{`Crawling URL`}</label>
                 <input
                   type="text"
                   className={`form-control ${

--- a/frontend/kendra-button-front/src/components/SiteMain.tsx
+++ b/frontend/kendra-button-front/src/components/SiteMain.tsx
@@ -1,26 +1,39 @@
+import { ChangeEvent, ReactElement, useEffect, useRef, useState } from 'react';
 import { Site, User } from '../types';
+import { deleteSite, updateSite } from '../graphql/queries';
 import { useMainContextImpls, useModalContextImpls } from '../contexts';
 
 import { EmbedInstruction } from './EmbedInstruction';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GraphQLResult } from '@aws-amplify/api-graphql';
+import { Loader } from './Loader';
 import { ProgressBar } from './ProgressBar';
-import { ReactElement } from 'react';
 import { Search } from './Search';
-import { SiteEdit } from './SiteEdit';
 import { callGraphql } from '../utils';
-import { deleteSite } from '../graphql/queries';
 import { faCode } from '@fortawesome/free-solid-svg-icons';
 
 interface Props {
   user?: User;
   siteInfo?: Site;
 }
+interface ResUpdateSite {
+  updateSite: {
+    site: Site;
+  };
+}
+
 const SiteMain = (props: Props): ReactElement => {
   const { setModalConfig } = useModalContextImpls();
   const { dispatch } = useMainContextImpls();
   const { site, scrapEndpoint, term, domain, crawlerStatus } =
     props.siteInfo || {};
+  const [domainInput, setDomainInput] = useState(domain);
+  const [isLoading, setIsLoading] = useState(false);
   const { total, done } = crawlerStatus || {};
+
+  useEffect(() => {
+    setDomainInput(domain);
+  }, [props.siteInfo]);
 
   const callEmbed = (): void => {
     setModalConfig({
@@ -56,6 +69,68 @@ const SiteMain = (props: Props): ReactElement => {
         }
       },
     });
+  };
+  const domainOnChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    console.log('onchange');
+    setDomainInput(e.target.value);
+  };
+  const onUpdateSite = async (): Promise<void> => {
+    if (isLoading) {
+      return;
+    }
+    if (!domainInput) {
+      setModalConfig({
+        type: 'plain',
+        display: true,
+        title: 'Update Site validation error',
+        content: '"Domain" field is not typed',
+      });
+      return;
+    }
+
+    const regDomain = domainInput.match(/^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i);
+    const compareDomain =
+      (regDomain && regDomain[1]) || domainInput.split('/')[0];
+    const domainFromEndpoint = scrapEndpoint.match(
+      /^https?\:\/\/([^\/?#]+)(?:[\/?#]|$)/i,
+    );
+
+    if (!domainFromEndpoint || domainFromEndpoint.length < 2) {
+      setModalConfig({
+        type: 'plain',
+        display: true,
+        title: 'Update Site validation error',
+        content: '"Crawling URL" value is invalid',
+      });
+      return;
+    }
+
+    if (domainFromEndpoint[1] !== compareDomain) {
+      setModalConfig({
+        type: 'plain',
+        display: true,
+        title: 'Update Site validation error',
+        content: '"Domain" field must match the domain url of "Crawling URL"',
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    const res: GraphQLResult<ResUpdateSite> = await callGraphql({
+      query: updateSite,
+      variables: {
+        site,
+        domain: domainInput,
+      },
+    });
+    setDomainInput(res.data.updateSite.site.domain);
+    setModalConfig({
+      type: 'plain',
+      display: true,
+      title: 'Update Site Success',
+      content: 'Update site info is successfully changed!',
+    });
+    setIsLoading(false);
   };
 
   return (
@@ -93,7 +168,7 @@ const SiteMain = (props: Props): ReactElement => {
             className="form-control"
             id="input-scrapEndpoint"
             placeholder={`input scrapEndpoint`}
-            defaultValue={scrapEndpoint}
+            value={scrapEndpoint}
             disabled
           />
         </div>
@@ -107,8 +182,8 @@ const SiteMain = (props: Props): ReactElement => {
             className="form-control"
             id="input-domain"
             placeholder={`input domain`}
-            defaultValue={domain}
-            disabled
+            onChange={domainOnChange}
+            value={domainInput}
           />
         </div>
         <div className="form-group">
@@ -119,12 +194,23 @@ const SiteMain = (props: Props): ReactElement => {
           <select
             className="custom-select"
             id="select-term"
-            defaultValue={term || 'd'}
+            value={term || 'd'}
             disabled
           >
             <option value={`d`}>{`Daily`}</option>
             <option value={`h`}>{`Hourly`}</option>
           </select>
+        </div>
+        <div className={`text-right`}>
+          <button
+            className={`btn ${
+              isLoading ? 'disabled' : ''
+            } btn-primary shadow-sm`}
+            onClick={onUpdateSite}
+          >
+            {isLoading && <Loader className={`mr-2`} />}
+            {`UPDATE SITE`}
+          </button>
         </div>
       </div>
       <hr className={`m-3`} />

--- a/frontend/kendra-button-front/src/components/SiteMain.tsx
+++ b/frontend/kendra-button-front/src/components/SiteMain.tsx
@@ -18,7 +18,8 @@ interface Props {
 const SiteMain = (props: Props): ReactElement => {
   const { setModalConfig } = useModalContextImpls();
   const { dispatch } = useMainContextImpls();
-  const { site, scrapEndpoint, term, crawlerStatus } = props.siteInfo || {};
+  const { site, scrapEndpoint, term, domain, crawlerStatus } =
+    props.siteInfo || {};
   const { total, done } = crawlerStatus || {};
 
   const callEmbed = (): void => {
@@ -59,6 +60,11 @@ const SiteMain = (props: Props): ReactElement => {
 
   return (
     <>
+      <div
+        className={`h3 px-3 d-flex justify-content-between align-items-center`}
+      >
+        {site}
+      </div>
       <div className={`d-flex justify-content-between p-3`}>
         <div
           className={`text-center text-danger`}
@@ -76,19 +82,32 @@ const SiteMain = (props: Props): ReactElement => {
           {/* <button className={`btn btn-warning shadow-sm`}>{`SAVE`}</button> */}
         </div>
       </div>
-      <SiteEdit site={site} />
       <div className={`p-3`}>
         <div className="form-group">
           <label
             className="form-control-label font-weight-bold"
             htmlFor="input-scrapEndpoint"
-          >{`Url to crawl`}</label>
+          >{`Crawling URL`}</label>
           <input
             type="text"
             className="form-control"
             id="input-scrapEndpoint"
             placeholder={`input scrapEndpoint`}
             defaultValue={scrapEndpoint}
+            disabled
+          />
+        </div>
+        <div className="form-group">
+          <label
+            className="form-control-label font-weight-bold"
+            htmlFor="input-scrapEndpoint"
+          >{`Domain`}</label>
+          <input
+            type="text"
+            className="form-control"
+            id="input-domain"
+            placeholder={`input domain`}
+            defaultValue={domain}
             disabled
           />
         </div>


### PR DESCRIPTION
## Action

- `updateSite` graphQL API를 호출하는 기능 구현
  - Site 추가 시 크롤링 할 `url`의 domain과 `Domain` 필드의 domain 이 일치해야 넘어가도록 validation 구현
  - 추가 된 site에서 `domain` 필드의 값 (e.g., domain.net -> domain.net/admin) 변경 시 validation 구현