### PR TITLE
Add tooltip to describe the meaning of inputs on SiteCreateModal

### DIFF
--- a/frontend/kendra-button-front/package.json
+++ b/frontend/kendra-button-front/package.json
@@ -20,6 +20,7 @@
     "next": "latest",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-tooltip": "^4.2.9",
     "yup": "^0.29.1"
   },
   "license": "ISC",

--- a/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
+++ b/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
@@ -4,11 +4,13 @@ import { ReactElement, useState } from 'react';
 import { callGraphql, regDomain } from '../utils';
 import { useMainContextImpls, useModalContextImpls } from '../contexts';
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { GraphQLResult } from '@aws-amplify/api-graphql';
 import { Logger } from 'aws-amplify';
 import ReactTooltip from 'react-tooltip';
 import { Site } from '../types';
 import { createSite } from '../graphql/queries';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { useFormik } from 'formik';
 
 const logger = new Logger('SiteCreateModal');
@@ -157,9 +159,14 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-site"
+                >{`Site Name`}</label>
+                <FontAwesomeIcon
+                  className={`mx-2`}
+                  icon={faInfoCircle}
+                  role="button"
                   data-tip
                   data-for="siteNameTip"
-                >{`Site Name`}</label>
+                />
                 <ReactTooltip id="siteNameTip" place="right" effect="solid">
                   Name of website to register
                 </ReactTooltip>
@@ -185,9 +192,14 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-url"
+                >{`Crawling URL`}</label>
+                <FontAwesomeIcon
+                  className={`mx-2`}
+                  icon={faInfoCircle}
+                  role="button"
                   data-tip
                   data-for="crawlingTip"
-                >{`Crawling URL`}</label>
+                />
                 <ReactTooltip id="crawlingTip" place="right" effect="solid">
                   Target to crawl
                 </ReactTooltip>
@@ -211,9 +223,14 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-domain"
+                >{`Domain`}</label>
+                <FontAwesomeIcon
+                  className={`mx-2`}
+                  icon={faInfoCircle}
+                  role="button"
                   data-tip
                   data-for="domainTip"
-                >{`Domain`}</label>
+                />
                 <ReactTooltip id="domainTip" place="right" effect="solid">
                   Website URL that you'd like to embed Kendra Button
                 </ReactTooltip>
@@ -239,9 +256,14 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="select-term"
+                >{`Crawl/Index Term`}</label>
+                <FontAwesomeIcon
+                  className={`mx-2`}
+                  icon={faInfoCircle}
+                  role="button"
                   data-tip
                   data-for="crawlTermTip"
-                >{`Crawl/Index Term`}</label>
+                />
                 <ReactTooltip id="crawlTermTip" place="right" effect="solid">
                   How frequently would you like to re-crawl your website?
                 </ReactTooltip>

--- a/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
+++ b/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
@@ -215,7 +215,7 @@ const SiteCreateModal = (): ReactElement => {
                   data-for="domainTip"
                 >{`Domain`}</label>
                 <ReactTooltip id="domainTip" place="right" effect="solid">
-                  Website URL that you'd like to embed Kendra-button
+                  Website URL that you'd like to embed Kendra Button
                 </ReactTooltip>
                 <input
                   type="text"
@@ -241,7 +241,7 @@ const SiteCreateModal = (): ReactElement => {
                   htmlFor="select-term"
                   data-tip
                   data-for="crawlTermTip"
-                >{`Crawl/index term`}</label>
+                >{`Crawl/Index Term`}</label>
                 <ReactTooltip id="crawlTermTip" place="right" effect="solid">
                   How frequently would you like to re-crawl your website?
                 </ReactTooltip>

--- a/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
+++ b/frontend/kendra-button-front/src/components/SiteCreateModal.tsx
@@ -6,6 +6,7 @@ import { useMainContextImpls, useModalContextImpls } from '../contexts';
 
 import { GraphQLResult } from '@aws-amplify/api-graphql';
 import { Logger } from 'aws-amplify';
+import ReactTooltip from 'react-tooltip';
 import { Site } from '../types';
 import { createSite } from '../graphql/queries';
 import { useFormik } from 'formik';
@@ -80,11 +81,11 @@ const SiteCreateModal = (): ReactElement => {
     ) {
       formik.setFieldError(
         'url',
-        'Domain name of this field must match the one entered for "Domain"',
+        'Domain name of this field must match the one entered for "Domain"'
       );
       formik.setFieldError(
         'domain',
-        'Domain name must match the one entered for "Crawling URL"',
+        'Domain name must match the one entered for "Crawling URL"'
       );
       return;
     }
@@ -156,7 +157,12 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-site"
+                  data-tip
+                  data-for="siteNameTip"
                 >{`Site Name`}</label>
+                <ReactTooltip id="siteNameTip" place="right" effect="solid">
+                  Name of website to register
+                </ReactTooltip>
                 <input
                   type="text"
                   className={`form-control ${
@@ -166,7 +172,7 @@ const SiteCreateModal = (): ReactElement => {
                   }`}
                   id="input-site"
                   name="site"
-                  placeholder={`input site`}
+                  placeholder={`Input site name`}
                   value={formik.values.site}
                   onBlur={formik.handleBlur}
                   onChange={formik.handleChange}
@@ -179,7 +185,12 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-url"
+                  data-tip
+                  data-for="crawlingTip"
                 >{`Crawling URL`}</label>
+                <ReactTooltip id="crawlingTip" place="right" effect="solid">
+                  Target to crawl
+                </ReactTooltip>
                 <input
                   type="text"
                   className={`form-control ${
@@ -187,7 +198,7 @@ const SiteCreateModal = (): ReactElement => {
                   }`}
                   id="input-url"
                   name="url"
-                  placeholder={`input url`}
+                  placeholder={`Input crawling url`}
                   value={formik.values.url}
                   onBlur={formik.handleBlur}
                   onChange={formik.handleChange}
@@ -200,7 +211,12 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="input-domain"
+                  data-tip
+                  data-for="domainTip"
                 >{`Domain`}</label>
+                <ReactTooltip id="domainTip" place="right" effect="solid">
+                  Website URL that you'd like to embed Kendra-button
+                </ReactTooltip>
                 <input
                   type="text"
                   className={`form-control ${
@@ -210,7 +226,7 @@ const SiteCreateModal = (): ReactElement => {
                   }`}
                   id="input-domain"
                   name="domain"
-                  placeholder={`input domain`}
+                  placeholder={`Input domain`}
                   value={formik.values.domain}
                   onBlur={formik.handleBlur}
                   onChange={formik.handleChange}
@@ -223,7 +239,12 @@ const SiteCreateModal = (): ReactElement => {
                 <label
                   className="form-control-label font-weight-bold"
                   htmlFor="select-term"
+                  data-tip
+                  data-for="crawlTermTip"
                 >{`Crawl/index term`}</label>
+                <ReactTooltip id="crawlTermTip" place="right" effect="solid">
+                  How frequently would you like to re-crawl your website?
+                </ReactTooltip>
                 <select
                   className="custom-select"
                   id="select-term"

--- a/frontend/kendra-button-front/yarn.lock
+++ b/frontend/kendra-button-front/yarn.lock
@@ -6058,6 +6058,14 @@ react-refresh@0.8.2:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.2.tgz#24bb0858eac92b0d7b0dd561747f0c9fd6c60327"
   integrity sha512-n8GXxo3DwM2KtFEL69DAVhGc4A1THn2qjmfvSo3nze0NLCoPbywazeJPqdp0RdSGLmyhQzeyA+XPXOobbYlkzg==
 
+react-tooltip@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.9.tgz#0dd08d14191f5d0e56b51c822fa20c2d81a24272"
+  integrity sha512-DgZyg5oxk9/orgePDLLeuDtlwwYv7CalJRahk9nNsoEJDzIO58GC6zSAet4bKTm6c01hg1z3EocP9H0nmMHTMA==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -7085,7 +7093,7 @@ uuid@^3.2.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^7.0.0:
+uuid@^7.0.0, uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==


### PR DESCRIPTION
# Description

사이트 추가 시 Domain 이라는 명칭이 직관적이지 않아 오해의 여지가 있어 각 항목을 설명하는 `Tooltip` 추가 
# Checklist

- [x] : Tooltip for `Site Name`
- [x] : Tooltip for `Crawling URL`
- [x] : Tooltip for `Domain`
- [x] : Tooltip for `Crawl/index term`

# Related Issue

Resolves #69 
