### PR TITLE
[Hotfix] Modify amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,8 +4,7 @@ backend:
     build:
       commands:
         - cd frontend/kendra-button-front
-        - chmod +x amplfypush.sh
-        - ./amplfypush.sh -e prod
+        - amplifyPush -e prod
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
# Description

 Among the contents of [frontend/kendra-button-front/amplfypush.sh](https://github.com/awskrug/kendra-button/blob/master/frontend/kendra-button-front/amplfypush.sh), it is strongly suspected that the `envCache` script fetches information from the `dev` stack instead of `prod` stack.

```
# Handle old or new config file based on simple flag
if [[ ${IS_SIMPLE} ]];
then
    echo "# Getting Amplify CLI Cloud-Formation stack info from environment cache"
    export STACKINFO="$(envCache --get stackInfo)" <--- 이 부분에서 계속 dev stack의 정보를 가져오는 것으로 강하게 의심
    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
    echo "# Store Amplify CLI Cloud-Formation stack info in environment cache"
    STACKINFO="$(amplify env get --json --name ${ENV})"
    envCache --set stackInfo ${STACKINFO}
    echo "STACKINFO="${STACKINFO}
else
    # old config file, above steps performed outside of this script
    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
fi

```

# Action

Decided to update [`amplifyPush`](https://github.com/aws-amplify/amplify-console/blob/master/scripts/amplifyPush.sh) helper script back