### PR TITLE
[Hotfix] Modify amplify.yml - 3

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,6 +4,7 @@ backend:
     build:
       commands:
         - cd frontend/kendra-button-front
+        - envCache --set stackInfo ""
         - amplifyPush -e prod
 frontend:
   phases:


### PR DESCRIPTION
# Description

After merged #76 , Amplify Build Image still import `dev` CloudFormation Stack information

# Action

Add `envCache --set stackInfo ""` command in /`amplify.yml`
refer to [this thread of issue](https://github.com/aws-amplify/amplify-console/issues/229#issuecomment-478107226)