### PR TITLE
[Hotfix] Fix deploy command in `dev` env

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ backend:
         - cd frontend/kendra-button-front
         - envCache --set stackInfo ""
         - chmod +x amplifypush.sh
-        - ./amplifypush.sh -e prod
+        - ./amplifypush.sh -e dev
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
## Description

Fix environment argument
- `prod` -> `dev`

```
version: 1
backend:
  phases:
    build:
      commands:
        - cd frontend/kendra-button-front
        - envCache --set stackInfo ""
        - chmod +x amplifypush.sh
-       - ./amplifypush.sh -e prod
+       - ./amplifypush.sh -e dev
```