### PR TITLE
[Hotfix] Fix build command in "frontend"

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -8,6 +8,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - cd frontend/kendra-button-service
         - yarn
     build:
       commands:


### PR DESCRIPTION
## Description

- Fix build command in "frontend"

**Amplify Frontend Build status**
```
[WARNING]: error Couldn't find a package.json file in "/codebuild/output/src505630829/src/kendra-button"
```